### PR TITLE
fix(DatePicker): defined all mandatory properties for using IconButton

### DIFF
--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -45,9 +45,10 @@ export const DatePicker: React.FC<Props> = ({ date }) => {
         <Box>
           <IconButton
             icon={IconNames.Calendar}
-            onPress={() => setShow(true)}
+            onClick={() => setShow(true)}
             colorScheme="primary"
             variant="major"
+            altText="show date picker"
           />
           {show && (
             <DTP

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import * as NativeBase from 'native-base';
-
 import * as Components from './components';
 
-export const components = { ...NativeBase, ...Components };
+type ComponentsType = typeof NativeBase & typeof Components;
+
+export const components: ComponentsType = { ...NativeBase, ...Components } as ComponentsType;
 
 export { default as theme } from './themes';
 export { default as tokens } from './tokens';


### PR DESCRIPTION
The project was not building because of the `IconButton` in the `DatePicker` missing the `onClick` and `altText` properties.
`IconButton` internally maps `onClick` to `onPress`, so the behavior should be the same.

Anyway looks like the component is not really being used in the project so far, so there's no real impact.